### PR TITLE
Fix additional links in pre-commit config and update OWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*    @goern @harshad16 @fridex

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.3.1
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -22,13 +22,13 @@ repos:
       - id: check-ast
       - id: debug-statements
 
-  - repo: git://github.com/pycqa/pydocstyle.git
-    rev: 5.1.1
+  - repo: https://github.com/pycqa/pydocstyle.git
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -36,19 +36,19 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.991
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: '3.8.4'
+    rev: '5.0.4'
     hooks:
       - id: flake8
         additional_dependencies: ['pep8-naming']

--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -17,12 +17,5 @@ managers:
   - name: info
   - name: version
     configuration:
-      maintainers:
-        - fridex
-        - goern
-        - harshad16
-        - pacospace
-      assignees:
-        - sesheta
       labels: [bot]
       changelog_file: true

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - codificat
+  - harshad16
   - kpostoffice
-  - pacospace
   - sesheta
 reviewers:
+  - codificat
   - harshad16
-  - saisankargochhayat
+  - kpostoffice
+
+emeritus_approvers:
+  - pacospace  # Apr 2022


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/si-cloc/pull/58

## This Pull Request implements

- update maintainers: `OWNERS` update, remove `CODEOWNERS`, remove maintainers from `.thoth.yaml`
- `git://` links don't work anymore, so replacing them with `https://`
- pre-commit autoupdate versions

